### PR TITLE
Feat/auth

### DIFF
--- a/evalap/api/config.py
+++ b/evalap/api/config.py
@@ -1,4 +1,5 @@
 import importlib.metadata
+import json
 import logging
 import os
 import tempfile
@@ -50,7 +51,11 @@ MFS_API_KEY_V2 = os.getenv("MFS_API_KEY_V2")
 #######################################################################
 ### Auth
 #######################################################################
+
 ADMIN_TOKENS = [os.getenv("ADMIN_TOKEN")] if os.getenv("ADMIN_TOKEN") else []
+USER_TOKENS = json.loads(os.getenv("USER_API_KEYS", "null"))
+if USER_TOKENS:
+    USER_TOKENS = {v: k for k, v in USER_TOKENS.items()}
 
 
 #######################################################################

--- a/evalap/api/endpoints.py
+++ b/evalap/api/endpoints.py
@@ -36,7 +36,9 @@ def _needs_output(db_exp):
 
 
 @router.post("/dataset", response_model=schemas.Dataset, tags=["datasets"])
-def create_dataset(dataset: schemas.DatasetCreate, db: Session = Depends(get_db)):
+def create_dataset(
+    dataset: schemas.DatasetCreate, db: Session = Depends(get_db), current_user=Depends(get_current_user)
+):
     try:
         db_dataset = crud.create_dataset(db, dataset)
         return db_dataset
@@ -49,12 +51,14 @@ def create_dataset(dataset: schemas.DatasetCreate, db: Session = Depends(get_db)
 
 
 @router.get("/datasets", response_model=list[schemas.Dataset], tags=["datasets"])
-def read_datasets(db: Session = Depends(get_db)):
+def read_datasets(db: Session = Depends(get_db), current_user=Depends(get_current_user)):
     return crud.get_datasets(db)
 
 
 @router.get("/dataset/{id}", response_model=schemas.Dataset | schemas.DatasetFull, tags=["datasets"])
-def read_dataset(id: int, with_df: bool = False, db: Session = Depends(get_db)):
+def read_dataset(
+    id: int, with_df: bool = False, db: Session = Depends(get_db), current_user=Depends(get_current_user)
+):
     dataset = crud.get_dataset(db, id)
     if dataset is None:
         raise HTTPException(status_code=410, detail="Dataset not found")
@@ -71,6 +75,7 @@ def read_dataset_by_query(
     name: str | None = None,
     with_df: bool = False,
     db: Session = Depends(get_db),
+    current_user=Depends(get_current_user),
 ):
     dataset = None
     if name:
@@ -92,7 +97,12 @@ def read_dataset_by_query(
 
 
 @router.patch("/dataset/{id}", response_model=schemas.Dataset, tags=["datasets"])
-def patch_dataset(id: int, dataset_patch: schemas.DatasetPatch, db: Session = Depends(get_db)):
+def patch_dataset(
+    id: int,
+    dataset_patch: schemas.DatasetPatch,
+    db: Session = Depends(get_db),
+    current_user=Depends(get_current_user),
+):
     db_dataset = crud.update_dataset(db, id, dataset_patch)
     if db_dataset is None:
         raise HTTPException(status_code=410, detail="Dataset not found")
@@ -104,7 +114,12 @@ def patch_dataset(id: int, dataset_patch: schemas.DatasetPatch, db: Session = De
     "/dataset/{id}",
     tags=["datasets"],
 )
-def delete_dataset(id: int, db: Session = Depends(get_db), admin_check=Depends(admin_only)):
+def delete_dataset(
+    id: int,
+    db: Session = Depends(get_db),
+    admin_check=Depends(admin_only),
+    current_user=Depends(get_current_user),
+):
     try:
         if not crud.remove_dataset(db, id):
             raise HTTPException(status_code=410, detail="Dataset not found")
@@ -119,7 +134,9 @@ def delete_dataset(id: int, db: Session = Depends(get_db), admin_check=Depends(a
 
 # @TODO write /dataset/{id}/download_parquet
 @router.post("/dataset/{id}/upload_parquet", response_model=schemas.Dataset, tags=["datasets"])
-async def upload_parquet_dataset(id: int, request: Request, db: Session = Depends(get_db)):
+async def upload_parquet_dataset(
+    id: int, request: Request, db: Session = Depends(get_db), current_user=Depends(get_current_user)
+):
     """
     Endpoint to handle streaming upload of Parquet data for a specific dataset.
 
@@ -190,7 +207,7 @@ async def upload_parquet_dataset(id: int, request: Request, db: Session = Depend
 
 
 @router.get("/metrics", response_model=list[Metric], tags=["metrics"])
-def read_metrics(db: Session = Depends(get_db)):
+def read_metrics(db: Session = Depends(get_db), current_user=Depends(get_current_user)):
     return crud.get_metrics(db)
 
 
@@ -205,7 +222,9 @@ def read_metrics(db: Session = Depends(get_db)):
     description="Launch an experiment. If a model is given, it will be use to generate the model output (answer), otherwise it will use the `output` column of the given dataset.",
     tags=["experiments"],
 )
-def create_experiment(experiment: schemas.ExperimentCreate, db: Session = Depends(get_db)):
+def create_experiment(
+    experiment: schemas.ExperimentCreate, db: Session = Depends(get_db), current_user=Depends(get_current_user)
+):
     try:
         db_exp = crud.create_experiment(db, experiment)
         if _needs_output(db_exp):
@@ -229,7 +248,12 @@ def create_experiment(experiment: schemas.ExperimentCreate, db: Session = Depend
     description="Update an experiment. The given metrics will be added (or rerun) to the existing results for this experiments. Use rerun_answers if want to re-generate the answers/output.",
     tags=["experiments"],
 )
-def patch_experiment(id: int, experiment_patch: schemas.ExperimentPatch, db: Session = Depends(get_db)):
+def patch_experiment(
+    id: int,
+    experiment_patch: schemas.ExperimentPatch,
+    db: Session = Depends(get_db),
+    current_user=Depends(get_current_user),
+):
     db_exp = crud.update_experiment(db, id, experiment_patch)
     if db_exp is None:
         raise HTTPException(status_code=410, detail="Experiment not found")
@@ -276,6 +300,7 @@ def delete_experiment(
     id: int,
     db: Session = Depends(get_db),
     admin_check=Depends(admin_only),
+    current_user=Depends(get_current_user),
 ):
     if not crud.remove_experiment(db, id):
         raise HTTPException(status_code=410, detail="Experiment not found")
@@ -299,6 +324,7 @@ def read_experiment(
     with_dataset: bool = False,
     with_eco: bool = False,
     db: Session = Depends(get_db),
+    current_user=Depends(get_current_user),
 ):
     experiment = crud.get_experiment(db, id)
     if experiment is None:
@@ -330,6 +356,7 @@ def read_experiments(
     set_id: int | None = None,
     orphan: bool = True,
     db: Session = Depends(get_db),
+    current_user=Depends(get_current_user),
 ):
     experiments = crud.get_experiments(
         db, skip=skip, limit=limit, backward=backward, set_id=set_id, orphan=orphan
@@ -351,7 +378,11 @@ def read_experiments(
     response_model=schemas.ExperimentSet,
     tags=["experiment_set"],
 )
-def create_experimentset(experimentset: schemas.ExperimentSetCreate, db: Session = Depends(get_db)):
+def create_experimentset(
+    experimentset: schemas.ExperimentSetCreate,
+    db: Session = Depends(get_db),
+    current_user=Depends(get_current_user),
+):
     try:
         db_expset = crud.create_experimentset(db, experimentset)
         for db_exp in db_expset.experiments:
@@ -376,7 +407,10 @@ def create_experimentset(experimentset: schemas.ExperimentSetCreate, db: Session
     tags=["experiment_set"],
 )
 def patch_experimentset(
-    id: int, experimentset_patch: schemas.ExperimentSetPatch, db: Session = Depends(get_db)
+    id: int,
+    experimentset_patch: schemas.ExperimentSetPatch,
+    db: Session = Depends(get_db),
+    current_user=Depends(get_current_user),
 ):
     db_expset = crud.update_experimentset(db, id, experimentset_patch)
     if db_expset is None:
@@ -428,7 +462,13 @@ def patch_experimentset(
     response_model=list[schemas.ExperimentSet],
     tags=["experiment_set"],
 )
-def read_experimentsets(skip: int = 0, limit: int = 100, backward: bool = True, db: Session = Depends(get_db)):
+def read_experimentsets(
+    skip: int = 0,
+    limit: int = 100,
+    backward: bool = True,
+    db: Session = Depends(get_db),
+    current_user=Depends(get_current_user),
+):
     experimentsets = crud.get_experimentsets(db, skip=skip, limit=limit, backward=backward)
     if experimentsets is None:
         raise HTTPException(status_code=410, detail="ExperimentSets not found")
@@ -441,7 +481,7 @@ def read_experimentsets(skip: int = 0, limit: int = 100, backward: bool = True, 
     response_model=schemas.ExperimentSet,
     tags=["experiment_set"],
 )
-def read_experimentset(id: int, db: Session = Depends(get_db)):
+def read_experimentset(id: int, db: Session = Depends(get_db), current_user=Depends(get_current_user)):
     experimentset = crud.get_experimentset(db, id)
     if experimentset is None:
         raise HTTPException(status_code=410, detail="ExperimentSet not found")
@@ -452,7 +492,12 @@ def read_experimentset(id: int, db: Session = Depends(get_db)):
     "/experiment_set/{id}",
     tags=["experiment_set"],
 )
-def delete_experimentset(id: int, db: Session = Depends(get_db), admin_check=Depends(admin_only)):
+def delete_experimentset(
+    id: int,
+    db: Session = Depends(get_db),
+    admin_check=Depends(admin_only),
+    current_user=Depends(get_current_user),
+):
     if not crud.remove_experimentset(db, id):
         raise HTTPException(status_code=410, detail="ExperimentSet not found")
     return "ok"
@@ -471,6 +516,7 @@ def retry_runs(
         description="Force retry of all unfinished runs, by resetting their status to pending. <!> Warning this can cause incoherent num_try/num_success value if another runner work on the same experiments.",
     ),
     db: Session = Depends(get_db),
+    current_user=Depends(get_current_user),
 ):
     experimentset = crud.get_experimentset(db, id)
     if experimentset is None:
@@ -542,6 +588,7 @@ def read_leaderboard(
     judge_model: str = None,
     limit: int = 100,
     db: Session = Depends(get_db),
+    current_user=Depends(get_current_user),
 ):
     return crud.get_leaderboard(
         db, metric_name=metric_name, dataset_name=dataset_name, judge_model=judge_model, limit=limit
@@ -554,12 +601,12 @@ def read_leaderboard(
 
 
 @router.get("/ops_metrics", response_model=schemas.OpsMetrics, tags=["ops"])
-def read_ops_metrics(db: Session = Depends(get_db)):
+def read_ops_metrics(db: Session = Depends(get_db), current_user=Depends(get_current_user)):
     return crud.get_ops_metrics(db)
 
 
 @router.get("/ops_eco", response_model=schemas.OpsEcoGlobal, tags=["ops"])
-def read_ops_eco(db: Session = Depends(get_db)):
+def read_ops_eco(db: Session = Depends(get_db), current_user=Depends(get_current_user)):
     answers_data = crud.get_ops_eco_answers(db)
     observations_data = crud.get_ops_eco_observation_table(db)
     return {
@@ -622,7 +669,9 @@ def _generate(input: GenerateInput):
 
 
 @router.post("/generate", response_model=schemas.Answer, tags=["generate"])
-async def generate(input: GenerateInput, db: Session = Depends(get_db)):
+async def generate(
+    input: GenerateInput, db: Session = Depends(get_db), current_user=Depends(get_current_user)
+):
     answer = None
     think = None
     error_msg = None
@@ -672,7 +721,9 @@ async def generate(input: GenerateInput, db: Session = Depends(get_db)):
     """,
     tags=["locust"],
 )
-def create_locustrun(run: schemas.LocustRunCreate, db: Session = Depends(get_db)):
+def create_locustrun(
+    run: schemas.LocustRunCreate, db: Session = Depends(get_db), current_user=Depends(get_current_user)
+):
     try:
         db_run = crud.create_locustrun(db, run)
         return db_run
@@ -691,7 +742,13 @@ def create_locustrun(run: schemas.LocustRunCreate, db: Session = Depends(get_db)
     description="Get the list of locust runs",
     tags=["locust"],
 )
-def get_locustruns(skip: int = 0, limit: int = 100, backward: bool = True, db: Session = Depends(get_db)):
+def get_locustruns(
+    skip: int = 0,
+    limit: int = 100,
+    backward: bool = True,
+    db: Session = Depends(get_db),
+    current_user=Depends(get_current_user),
+):
     try:
         db_runs = crud.get_locustruns(db, skip=skip, limit=limit, backward=backward)
         return db_runs
@@ -710,7 +767,7 @@ def get_locustruns(skip: int = 0, limit: int = 100, backward: bool = True, db: S
     description="Get locust run with data.",
     tags=["locust"],
 )
-def get_locustrun(run_id: int, db: Session = Depends(get_db)):
+def get_locustrun(run_id: int, db: Session = Depends(get_db), current_user=Depends(get_current_user)):
     try:
         db_run = crud.get_locustrun(db, run_id)
         return db_run
@@ -744,7 +801,9 @@ def get_locustrun(run_id: int, db: Session = Depends(get_db)):
     """,
     tags=["loadtesting"],
 )
-def create_loadtesting(run: schemas.LoadTestingCreate, db: Session = Depends(get_db)):
+def create_loadtesting(
+    run: schemas.LoadTestingCreate, db: Session = Depends(get_db), current_user=Depends(get_current_user)
+):
     try:
         db_run = crud.create_loadtesting(db, run)
         return db_run
@@ -763,7 +822,13 @@ def create_loadtesting(run: schemas.LoadTestingCreate, db: Session = Depends(get
     description="Get the list of loadtesting runs",
     tags=["loadtesting"],
 )
-def get_loadtestings(skip: int = 0, limit: int = 100, backward: bool = True, db: Session = Depends(get_db)):
+def get_loadtestings(
+    skip: int = 0,
+    limit: int = 100,
+    backward: bool = True,
+    db: Session = Depends(get_db),
+    current_user=Depends(get_current_user),
+):
     try:
         db_runs = crud.get_loadtestings(db, skip=skip, limit=limit, backward=backward)
         return db_runs
@@ -782,7 +847,7 @@ def get_loadtestings(skip: int = 0, limit: int = 100, backward: bool = True, db:
     description="Get loadtesting run with data.",
     tags=["loadtesting"],
 )
-def get_loadtesting(run_id: int, db: Session = Depends(get_db)):
+def get_loadtesting(run_id: int, db: Session = Depends(get_db), current_user=Depends(get_current_user)):
     try:
         db_run = crud.get_loadtesting(db, run_id)
         return db_run
@@ -800,7 +865,7 @@ def get_loadtesting(run_id: int, db: Session = Depends(get_db)):
     description="Remove loadtesting run.",
     tags=["loadtesting"],
 )
-def remove_loadtesting(run_id: int, db: Session = Depends(get_db)):
+def remove_loadtesting(run_id: int, db: Session = Depends(get_db), current_user=Depends(get_current_user)):
     try:
         if not crud.remove_loadtesting(db, run_id):
             raise HTTPException(status_code=410, detail="LoadTesting not found")

--- a/evalap/api/endpoints.py
+++ b/evalap/api/endpoints.py
@@ -16,7 +16,7 @@ from evalap.api.db import get_db
 from evalap.api.errors import CustomIntegrityError, SchemaError
 from evalap.api.metrics import Metric, metric_registry
 from evalap.api.models import is_equal
-from evalap.api.security import admin_only
+from evalap.api.security import admin_only, get_current_user
 from evalap.clients import LlmClient, MCPBridgeClient, multi_step_generate
 from evalap.logger import logger
 from evalap.runners import dispatch_retries, dispatch_tasks

--- a/evalap/api/security.py
+++ b/evalap/api/security.py
@@ -1,8 +1,33 @@
-from fastapi import Header, HTTPException
+from fastapi import Depends, Header, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
-from evalap.api.config import ADMIN_TOKENS
+from evalap.api.config import ADMIN_TOKENS, USER_TOKENS
+
+# Security scheme for Bearer tokens
+security = HTTPBearer()
 
 
 async def admin_only(x_evalap_admin: str = Header(default=None)):
     if ADMIN_TOKENS and x_evalap_admin not in ADMIN_TOKENS:
-        raise HTTPException(status_code=401, detail="Unauthorized: Please contact an admin to perform this request.")
+        raise HTTPException(
+            status_code=401, detail="Unauthorized: Please contact an admin to perform this request."
+        )
+
+
+def get_current_user(credentials: HTTPAuthorizationCredentials = Depends(security)) -> str:
+    """
+    Verify the bearer token and return the user if valid.
+    This function assumes your authentication system already exists.
+    """
+    if not USER_TOKENS:
+        # Allow if no user tokens are given at startup
+        return "ok"
+
+    token = credentials.credentials
+    try:
+        return USER_TOKENS[token]
+    except:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid authentication credentials",
+        )

--- a/evalap/api/security.py
+++ b/evalap/api/security.py
@@ -4,7 +4,7 @@ from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from evalap.api.config import ADMIN_TOKENS, USER_TOKENS
 
 # Security scheme for Bearer tokens
-security = HTTPBearer()
+security = HTTPBearer(auto_error=False)
 
 
 async def admin_only(x_evalap_admin: str = Header(default=None)):
@@ -23,8 +23,8 @@ def get_current_user(credentials: HTTPAuthorizationCredentials = Depends(securit
         # Allow if no user tokens are given at startup
         return "ok"
 
-    token = credentials.credentials
     try:
+        token = credentials.credentials
         return USER_TOKENS[token]
     except:
         raise HTTPException(

--- a/evalap/ui/demo_streamlit/utils.py
+++ b/evalap/ui/demo_streamlit/utils.py
@@ -20,7 +20,7 @@ def fetch(method, endpoint, data=None, token=None):
 
     # Setup authorization
     # --
-    if method == "get" and not token:
+    if method == "get":
         token = token if token else EVALAP_FRONTEND_TOKEN
 
     if token:

--- a/evalap/ui/demo_streamlit/utils.py
+++ b/evalap/ui/demo_streamlit/utils.py
@@ -1,25 +1,38 @@
+import hashlib
 import json
+import os
 import re
-import time
 from collections import defaultdict
 from copy import deepcopy
+from typing import Optional
+
 import pandas as pd
 import requests
 import streamlit as st
-from typing import Optional
-import hashlib
 
 API_BASE_URL = "http://localhost:8000/v1"
+EVALAP_FRONTEND_TOKEN = os.getenv("EVALAP_FRONTEND_TOKEN")
 
-
-def fetch(method, endpoint, data=None):
+def fetch(method, endpoint, data=None, token=None):
     func = getattr(requests, method)
     q = ""
     kw = {}
+
+    # Setup authorization
+    # --
+    if method == "get" and not token:
+        token = token if token else EVALAP_FRONTEND_TOKEN
+
+    if token:
+        kw["headers"] = {"Authorization": f"Bearer {token}"}
+
+    # Setup HTTP payload
+    # --
     if method == "get" and data:
         q = "?" + "&".join([f"{k}={v}" for k, v in data.items()])
     elif data:
         kw["json"] = data
+
 
     response = func(f"{API_BASE_URL}{endpoint}{q}", **kw)
     if response.status_code == 200:


### PR DESCRIPTION
This PR changes the way we authorize users if a ``USER_API_KEYS`` environment variable containing the secret is provided when launching evalap. If nothing is provided, no authorization is required.

The frontend (Streamlit) will use a given key for "GET" requests to keep the data accessible for reading by all users.
However, for "POST" requests, you will need to pass a token to the `fetch` method in Streamlit. This is where you need to obtain the token from the user by displaying a floating or modal page where the user can enter their key.

@AudreyCLEVY 
