### PR TITLE
fix: improve ruff rules selection

### DIFF
--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -52,7 +52,7 @@ jobs:
       #  run: uv run pre-commit run --all-files
 
       - name: Lint with ruff
-        run: uv run ruff check --output-format=github --config=.pyproject.pre-commit.toml
+        run: uv run ruff check --output-format=github --config=pyproject.toml --select=F,Q,I
 
       - name: Check formatting
         run: uv run ruff format --check --diff --config=pyproject.toml

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -52,10 +52,10 @@ jobs:
       #  run: uv run pre-commit run --all-files
 
       - name: Lint with ruff
-        run: uv run ruff check --output-format=github
+        run: uv run ruff check --output-format=github --config=.pyproject.pre-commit.toml
 
       - name: Check formatting
-        run: uv run ruff format --check --diff
+        run: uv run ruff format --check --diff --config=pyproject.toml
 
       - name: Setup test database
         env:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,8 @@ repos:
         args: [
             --fix,
             --exit-non-zero-on-fix,
-            --config=.pyproject.pre-commit.toml,
+            --config=pyproject.toml,
+            "--select=F,Q,I,"
           ]
       # Run the formatter
       - id: ruff-format

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,15 +7,18 @@ repos:
       - id: ruff
         types_or: [python, pyi]
         args: [
-          --fix, 
-          --exit-non-zero-on-fix, 
-          --config=pyproject.toml,
-          --select=F,I,Q,B  # Override select rules for pre-commit
-        ]
+            --fix,
+            --exit-non-zero-on-fix,
+            --config=pyproject.toml,
+            "--select=F,Q,I", # Override select rules for pre-commit
+          ]
       # Run the formatter
       - id: ruff-format
         types_or: [python, pyi]
-        args: [--config=pyproject.toml]
+        args: [
+            --config=pyproject.toml,
+            "--select=F,Q,I", # Override select rules for pre-commit
+          ]
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,16 +9,12 @@ repos:
         args: [
             --fix,
             --exit-non-zero-on-fix,
-            --config=pyproject.toml,
-            "--select=F,Q,I", # Override select rules for pre-commit
+            --config=.pyproject.pre-commit.toml,
           ]
       # Run the formatter
       - id: ruff-format
         types_or: [python, pyi]
-        args: [
-            --config=pyproject.toml,
-            "--select=F,Q,I", # Override select rules for pre-commit
-          ]
+        args: [--config=pyproject.toml]
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,12 @@ repos:
       # Run the linter with auto-fixes
       - id: ruff
         types_or: [python, pyi]
-        args: [--fix, --exit-non-zero-on-fix, --config=pyproject.toml]
+        args: [
+          --fix, 
+          --exit-non-zero-on-fix, 
+          --config=pyproject.toml,
+          --select=F,I,Q,B  # Override select rules for pre-commit
+        ]
       # Run the formatter
       - id: ruff-format
         types_or: [python, pyi]

--- a/.pyproject.pre-commit.toml
+++ b/.pyproject.pre-commit.toml
@@ -1,4 +1,5 @@
+[tool.ruff]
 extend = "pyproject.toml"  # Inherit line-length and other settings
 
-[tool.ruff]
+[tool.ruff.lint]
 select = ["F", "Q", "I"]  # Override only select for pre-commit

--- a/.pyproject.pre-commit.toml
+++ b/.pyproject.pre-commit.toml
@@ -1,5 +1,0 @@
-[tool.ruff]
-extend = "pyproject.toml"  # Inherit line-length and other settings
-
-[tool.ruff.lint]
-select = ["F", "Q", "I"]  # Override only select for pre-commit

--- a/.pyproject.pre-commit.toml
+++ b/.pyproject.pre-commit.toml
@@ -1,0 +1,4 @@
+extend = "pyproject.toml"  # Inherit line-length and other settings
+
+[tool.ruff]
+select = ["F", "Q", "I"]  # Override only select for pre-commit

--- a/evalap/runners/main.py
+++ b/evalap/runners/main.py
@@ -1,6 +1,5 @@
 import logging
 import signal
-import sys
 import threading
 
 import zmq

--- a/evalap/ui/demo_streamlit/views/experiments_set.py
+++ b/evalap/ui/demo_streamlit/views/experiments_set.py
@@ -3,8 +3,6 @@ import re
 from collections import defaultdict
 from datetime import datetime
 from io import StringIO
-from itertools import groupby
-from operator import itemgetter
 from urllib.parse import quote, unquote
 
 import numpy as np

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,12 @@ exclude = ["evalap/api/alembic/versions/", "notebooks/"]
 
 [tool.ruff.lint]
 select = [
-    "I",  # isort
+    "F",    # Pyflakes (includes undefined variables)
+    "E",    # pycodestyle errors
+    "W",    # pycodestyle warnings
+    "Q",    # flake8-quotes (quote style consistency)
+    "B",    # flake8-bugbear (likely bugs and design problems)
+    "I",    # isort
 ]
 fixable = ["ALL"]
 unfixable = []


### PR DESCRIPTION
I have adapted the CI in order to : 
- have a broader ruff rules selection in the pyproject to keep to possibility to detect commons error
- I have restricted the ruff rules selection in pre-commit ruff to avoid dangerous breaking changes as it runs with auto fix options 

@AudreyCLEVY @kaaloo 