### PR TITLE
ci: skip PR checks for draft pull requests

### DIFF
--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   checks:
     name: Checks
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 10
 

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -2,13 +2,12 @@ name: PR Checks
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
 
 jobs:
   checks:
     name: Checks
-    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 10
 

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -2,12 +2,19 @@ name: PR Checks
 
 on:
   pull_request:
+    # Run on these PR events:
+    # - opened: When PR is first created
+    # - synchronize: When new commits are pushed
+    # - reopened: When a closed PR is reopened
+    # - ready_for_review: When a draft PR is marked as ready
     types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
 
 jobs:
   checks:
     name: Checks
+    # Skip if this is a draft PR (github.event.pull_request.draft is true for draft PRs)
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
 


### PR DESCRIPTION
## Description
This PR updates the GitHub Actions workflow to optimize CI/CD checks by skipping them for draft PRs, which helps conserve GitHub Actions compute resources across the organization.

## Changes
- Added `ready_for_review` to the PR event types to handle draft PR transitions
- Added explicit draft status check with `if: ${{ !github.event.pull_request.draft }}`
- Added detailed comments explaining each PR event type and the draft check
- Maintained all existing PR event types for comprehensive coverage

## Related Issue
Closes #255

## Testing
- [x] Verified that the workflow runs on non-draft PRs
- [x] Verified that the workflow is skipped on draft PRs
- [x] Verified that checks run when a draft PR is marked as ready for review
- [x] Verified that checks run on new commits to non-draft PRs
- [x] Verified that checks run when a closed PR is reopened